### PR TITLE
bugfix: rename `popup` element

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,5 +1,5 @@
 angular.module('bookmap', ['ui.bootstrap'])
-  .component('popup', {
+  .component('popUp', {
 
     controller(bookMarks, userSettings, $timeout, $rootScope) {
       

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 </head>
 
 <body>
-  <popup ng-app="bookmap"> If you're seeing this, somethings gone wrong!! </popup>
+  <pop-up ng-app="bookmap"> If you're seeing this, somethings gone wrong!! </pop-up>
 </body>
 
 </html>


### PR DESCRIPTION
### Bug description
The extension displays nothing when clicked after Chrome version > 90.

### Cause
In recent versions, Chrome is adding support for the proposed standard Open UI `<popup>`, which conflicts with custom elements named `<popup>`. (https://support.google.com/chrome/thread/106244569?hl=en)

### Modification
Fixed by simply renaming the `<popup>` element to `<pop-up>`.